### PR TITLE
[stable/instana-agent] Allow to configure multiple backends

### DIFF
--- a/stable/instana-agent/Chart.yaml
+++ b/stable/instana-agent/Chart.yaml
@@ -21,4 +21,4 @@ maintainers:
 name: instana-agent
 sources:
 - https://github.com/instana/instana-agent-docker
-version: 1.0.29
+version: 1.0.30

--- a/stable/instana-agent/templates/configmap.yaml
+++ b/stable/instana-agent/templates/configmap.yaml
@@ -42,3 +42,13 @@ data:
   {{- if .Values.agent.configuration_yaml -}}
   {{ .Values.agent.configuration_yaml | nindent 4 }}
   {{- end }}
+  {{- if .Values.agent.additionalBackends }}
+  {{- range $index,$backend := .Values.agent.additionalBackends }}
+  {{ $backendIndex :=add $index 2 -}}
+  additional-backend-{{$backendIndex}}: |
+    host={{ .endpointHost }}
+    port={{ default 443 .endpointPort }}
+    key={{ .key }}
+    protocol=HTTP/2
+  {{- end }}
+  {{- end }}

--- a/stable/instana-agent/templates/daemonset.yaml
+++ b/stable/instana-agent/templates/daemonset.yaml
@@ -134,6 +134,14 @@ spec:
             - name: repo
               mountPath: /opt/instana/agent/data/repo
             {{- end }}
+            {{- if .Values.agent.additionalBackends }}
+            {{- range $index,$backend := .Values.agent.additionalBackends }}
+            {{ $backendIndex :=add $index 2 -}}
+            - name: additional-backend-{{$backendIndex}}
+              subPath: additional-backend-{{$backendIndex}}
+              mountPath: /opt/instana/agent/etc/instana/com.instana.agent.main.sender.Backend-{{$backendIndex}}.cfg
+            {{- end }}
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /status
@@ -205,6 +213,15 @@ spec:
         - name: repo
           hostPath:
             path: {{ .Values.agent.host.repository }}
+        {{- end }}
+        {{- if .Values.agent.additionalBackends }}
+        {{- $fullname := include "instana-agent.fullname" . -}}
+        {{- range $index,$backend := .Values.agent.additionalBackends }}
+        {{ $backendIndex :=add $index 2 -}}
+        - name: additional-backend-{{$backendIndex}}
+          configMap:
+            name: {{ $fullname }}
+        {{- end }}
         {{- end }}
 {{- end -}}
 {{- end -}}

--- a/stable/instana-agent/values.yaml
+++ b/stable/instana-agent/values.yaml
@@ -65,6 +65,13 @@ agent:
   configuration_yaml: |
     # Place agent configuration here
 
+  # These are additional backends the Instana agent will report to besides
+  # the one configured via the `agent.endpointHost`, `agent.endpointPort` and `agent.key` setting
+  additionalBackends: []
+    # - endpointHost: ingress.instana.io
+    #   endpointPort: 443
+    #   key: <agent_key>
+
   # agent.redactKubernetesSecrets sets the INSTANA_KUBERNETES_REDACT_SECRETS environment variable.
   # redactKubernetesSecrets: null
 


### PR DESCRIPTION
#### What this PR does / why we need it:

When defining a Daemonset manually, one has the (very toil-intensive) option to configure multiple backends to which the agent should report as documented at [1]. However, there is no way to add configmap entries, volumes and volume mounts to the `instana-agent` container in the current Helm chart, so agents installed via Helm are limited to report to one backend.

This change introduces an easy way to set up additional backends to which the Instana agent will report to.

[1] https://www.instana.com/docs/setup_and_manage/host_agent/configuration/#configure-multiple-backends

#### Special notes for your reviewer:

This PR fills is a functional gap for migrating the PKS support to be based on the official Instana Helm chart rather than a [bespoke Daemonset](https://github.com/instana/pcf-tile/blob/master/agent-pks-release/jobs/instana-daemonset-deployer/templates/config/instana-agent.yaml.erb).

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
