### PR TITLE
quote star character for listenAddress in values

### DIFF
--- a/instana-agent/values.yaml
+++ b/instana-agent/values.yaml
@@ -19,7 +19,7 @@ agent:
   # keysSecret: null
 
   # agent.listenAddress is the IP address the agent HTTP server will listen to.
-  # listenAddress: *
+  # listenAddress: "*"
 
   # agent.endpointHost is the hostname of the Instana server your agents will connect to.
   endpointHost: ingress-red-saas.instana.io


### PR DESCRIPTION
# missing quotes in helm values

## Why
Support advised to enable listenining on * for the instana-agent, but the helm does not validate if we comment out the line

$ git diff
diff --git a/instana-agent/values.yaml b/instana-agent/values.yaml
index 82fa1fa..c35e2c7 100644
--- a/instana-agent/values.yaml
+++ b/instana-agent/values.yaml
@@ -19,7 +19,7 @@ agent:
   # keysSecret: null
 
   # agent.listenAddress is the IP address the agent HTTP server will listen to.
-  # listenAddress: *
+  listenAddress: *

$ helm lint instana-agent
==> Linting instana-agent
[ERROR] values.yaml: unable to parse YAML: error converting YAML to JSON: yaml: line 22: did not find expected alphabetic or numeric character
[ERROR] templates/: cannot load values.yaml: error converting YAML to JSON: yaml: line 22: did not find expected alphabetic or numeric character

Error: 1 chart(s) linted, 1 chart(s) failed

## What

If we quote the value, the helm chart validates and deploys/upgrades.

## Checklist

$ git diff
diff --git a/instana-agent/values.yaml b/instana-agent/values.yaml
index 82fa1fa..7c3b2a2 100644
--- a/instana-agent/values.yaml
+++ b/instana-agent/values.yaml
@@ -19,7 +19,7 @@ agent:
   # keysSecret: null
 
   # agent.listenAddress is the IP address the agent HTTP server will listen to.
-  # listenAddress: *
+  listenAddress: "*"

$ helm lint instana-agent
==> Linting instana-agent

1 chart(s) linted, 0 chart(s) failed

- [ Y ] Backwards compatible?
- [ N ] Documentation added to the README.md?
- [ N ] Changelog updated?
