### PR TITLE
Fix additional backend configuration

### DIFF
--- a/instana-agent/templates/_helpers.tpl
+++ b/instana-agent/templates/_helpers.tpl
@@ -260,7 +260,7 @@ Composes a container image from a dict containing a "name" field (required), "ta
 {{ $backendIndex :=add $index 2 -}}
 - name: additional-backend-{{$backendIndex}}
   configMap:
-    name: {{ include "instana-agent.fullname" . }}
+    name: {{ include "instana-agent.fullname" $ }}
 {{- end }}
 {{- end }}
 {{- end -}}


### PR DESCRIPTION
# Additional backend configuration fails because of wrong template scope

## Why
When adding an additional backend, the named template `instana-agent.fullname` is rendered with scope `.`
This causes the following error:
`Error: template: instana-agent/templates/agent-daemonset.yaml:164:12: executing "instana-agent/templates/agent-daemonset.yaml" at <include "instana-agent.commonVolumes" .>: error calling include: template: instana-agent/templates/_helpers.tpl:263:13: executing "instana-agent.commonVolumes" at <include "instana-agent.fullname" .>: error calling include: template: instana-agent/templates/_helpers.tpl:15:14: executing "instana-agent.fullname" at <.Values.fullnameOverride>: nil pointer evaluating interface {}.fullnameOverride`

## What
When changing the scope from `.` to `$`, the template can properly reference `.Values.fullnameOverride`
 again.
## Checklist

<!-- Please tick of these checklist items if applicable (or remove if not applicable). -->

- [x] Backwards compatible?
- [ ] Documentation added to the README.md?
- [ ] Changelog updated?
