### PR TITLE
Upgrade leader-elector to 0.5.6 to be multi-arch capable

### DIFF
--- a/instana-agent/values.yaml
+++ b/instana-agent/values.yaml
@@ -164,7 +164,7 @@ leaderElector:
     # leaderElector.image.digest is the digest (a.k.a. Image ID) of the leader elector container image; if specified, it has priority over leaderElector.image.digest, which will be ignored.
     #digest:
     # leaderElector.image.tag is the tag name of the agent container image; if leaderElector.image.digest is specified, this property is ignored.
-    tag: 0.5.4
+    tag: 0.5.6
   port: 42655
 
 # openshift specifies whether the cluster role should include openshift permissions and other tweaks to the YAML.


### PR DESCRIPTION
# Upgrade to instana/leader-elector:0.5.6

## Why

The leader-elector 0.5.6 brings support for the following platforms:

* linux/amd64
* linux/s390x
* linux/arm64

## What

Upgrade to leader-elector image tag 0.5.6.

## Checklist

- [x] Backwards compatible?
- [x] Documentation added to the README.md?
- [ ] Changelog updated?
