### PR TITLE
Bump leader-elector image to v0.5.13 and pull from IBM Cloud Containe…

### DIFF
--- a/instana-agent/values.yaml
+++ b/instana-agent/values.yaml
@@ -174,11 +174,11 @@ cluster:
 leaderElector:
   image:
     # leaderElector.image.name is the name of the container image of the leader elector.
-    name: instana/leader-elector
+    name: gcr.io/instana/leader-elector
     # leaderElector.image.digest is the digest (a.k.a. Image ID) of the leader elector container image; if specified, it has priority over leaderElector.image.digest, which will be ignored.
     #digest:
     # leaderElector.image.tag is the tag name of the agent container image; if leaderElector.image.digest is specified, this property is ignored.
-    tag: 0.5.10
+    tag: 0.5.13
   port: 42655
 
 # openshift specifies whether the cluster role should include openshift permissions and other tweaks to the YAML.


### PR DESCRIPTION
…r Registry (icr.io/instana/leader-elector). No code changes have been made.

# Bump leader-elector image to v0.5.13 and pull from icr.io/instana/leader-elector.

## Why

Docker.io will be deprecated beginning 2022. This change pulls the leader-elector image from the public IBM Cloud Container Registry at `icr.io/instana/leader-elector`.

## What

Change image name & version of the leader-elector in `values.yaml`.

## Checklist

<!-- Please tick of these checklist items if applicable (or remove if not applicable). -->

- [x] Backwards compatible?
- [x] Documentation added to the README.md?
- [ ] Changelog updated?
