### PR TITLE
Reference agent & leader-elector images from IBM Cloud Container Registry

### DIFF
--- a/instana-agent/README.md
+++ b/instana-agent/README.md
@@ -7,7 +7,7 @@ This chart adds the Instana Agent to all schedulable nodes in your cluster via a
 
 ## Prerequisites
 
-* Kubernetes 1.9.x - 1.18.x OR OpenShift 4.x
+* Kubernetes 1.9.x - 1.23.x OR OpenShift 4.x
 * Helm 3
 
 ## Installation
@@ -284,6 +284,10 @@ It is advised to use the `kubernetes.deployment.enabled=true` mode on clusters o
 The `kubernetes.deployment.pod.requests.cpu`, `kubernetes.deployment.pod.requests.memory`, `kubernetes.deployment.pod.limits.cpu` and `kubernetes.deployment.pod.limits.memory` settings, on the other hand, allows you to change the sizing of the `kubernetes-sensor` pods.
 
 ## Changelog
+
+### 1.2.30
+
+* Pull `instana/agent` and `instana/leader-elector` images from IBM Cloud Container Registry at `icr.io/instana`.
 
 ### 1.2.29
 

--- a/instana-agent/values.yaml
+++ b/instana-agent/values.yaml
@@ -46,7 +46,7 @@ agent:
 
   image:
     # agent.image.name is the name of the container image of the Instana agent.
-    name: instana/agent
+    name: icr.io/instana/agent
     # agent.image.digest is the digest (a.k.a. Image ID) of the agent container image; if specified, it has priority over agent.image.tag, which will be ignored.
     #digest:
     # agent.image.tag is the tag name of the agent container image; if agent.image.digest is specified, this property is ignored.
@@ -174,11 +174,11 @@ cluster:
 leaderElector:
   image:
     # leaderElector.image.name is the name of the container image of the leader elector.
-    name: instana/leader-elector
+    name: icr.io/instana/leader-elector
     # leaderElector.image.digest is the digest (a.k.a. Image ID) of the leader elector container image; if specified, it has priority over leaderElector.image.digest, which will be ignored.
     #digest:
     # leaderElector.image.tag is the tag name of the agent container image; if leaderElector.image.digest is specified, this property is ignored.
-    tag: 0.5.10
+    tag: 0.5.13
   port: 42655
 
 # openshift specifies whether the cluster role should include openshift permissions and other tweaks to the YAML.


### PR DESCRIPTION

## Why

Public container images need to be migrated to IBM Cloud Container Registry.

## What

Pull agent & leader-electopr from icr.io instead public dockerhub.

## Checklist

<!-- Please tick of these checklist items if applicable (or remove if not applicable). -->

- [x] Backwards compatible?
- [x] Changelog updated?
