### PR TITLE
Remove service topologyKeys due to removal in K8S 1.22

### DIFF
--- a/instana-agent/README.md
+++ b/instana-agent/README.md
@@ -285,6 +285,10 @@ The `kubernetes.deployment.pod.requests.cpu`, `kubernetes.deployment.pod.request
 
 ## Changelog
 
+### 1.2.34
+
+Remove service topologyKeys alpha feature due to removal in Kubernetes 1.22
+
 ### 1.2.33
 
 * Bump leader-elector image to v0.5.15 (Update dependencies)

--- a/instana-agent/templates/service.yaml
+++ b/instana-agent/templates/service.yaml
@@ -28,6 +28,4 @@ spec:
       port: 4317
       targetPort: 4317
     {{- end }}
-  topologyKeys:
-    - "kubernetes.io/hostname"
 {{- end -}}


### PR DESCRIPTION
# Remove deprecated field due to removal in Kubernetes 1.22

## Why

Hi there,
in Kubernetes 1.22 the topology key alpha within a Service resources has been removed. See following PR https://github.com/kubernetes/kubernetes/pull/102412.

The installation of the instana-agent helm chart does not work at the moment on K8S 1.22 cluster.
Therefore would be good to merge this PR as soon as possible.

## What

Change should be trivial.

## Checklist

<!-- Please tick of these checklist items if applicable (or remove if not applicable). -->

- [X] Backwards compatible?
- [x] Documentation added to the README.md?
- [X] Changelog updated?
