### PR TITLE
Add pdb and affinity override for k8sensor

### DIFF
--- a/instana-agent/Chart.yaml
+++ b/instana-agent/Chart.yaml
@@ -19,4 +19,4 @@ maintainers:
 name: instana-agent
 sources:
 - https://github.com/instana/instana-agent-docker
-version: 1.2.63
+version: 1.2.64

--- a/instana-agent/README.md
+++ b/instana-agent/README.md
@@ -334,6 +334,10 @@ zones:
 ```
 
 ## Changelog
+### 1.2.64
+* Add settings override for k8s-sensor affinity
+* Add optional pod disruption budget for k8s-sensor
+
 ### 1.2.63
 * Add RBAC required to allow access to /metrics end-points.
 

--- a/instana-agent/templates/k8s-sensor-deployment.yaml
+++ b/instana-agent/templates/k8s-sensor-deployment.yaml
@@ -124,19 +124,7 @@ spec:
         {{- toYaml .Values.k8s_sensor.deployment.pod.tolerations | nindent 8 }}
       {{- end }}
       affinity:
-        podAntiAffinity:
-          # Soft anti-affinity policy: try not to schedule multiple kubernetes-sensor pods on the same node.
-          # If the policy is set to "requiredDuringSchedulingIgnoredDuringExecution", if the cluster has
-          # fewer nodes than the amount of desired replicas, `helm install/upgrade --wait` will not return.
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: instana/agent-mode
-                  operator: In
-                  values: [ KUBERNETES ]
-              topologyKey: "kubernetes.io/hostname"
+        {{- toYaml .Values.k8s_sensor.deployment.pod.affinity | nindent 8 }}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/instana-agent/templates/k8s-sensor-pod-disruption-budget.yaml
+++ b/instana-agent/templates/k8s-sensor-pod-disruption-budget.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.k8s_sensor.podDisruptionBudget.enabled  -}}
+{{- if (gt (int .Values.k8s_sensor.deployment.replicas) 1) }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: k8sensor
+spec:
+  selector:
+    matchLabels:
+      {{- include "k8s-sensor.selectorLabels" . | nindent 6 }}
+  minAvailable: {{ sub (int .Values.k8s_sensor.deployment.replicas) 1 }}
+{{- end -}}
+{{- end -}}

--- a/instana-agent/values.yaml
+++ b/instana-agent/values.yaml
@@ -255,6 +255,23 @@ k8s_sensor:
         memory: 1536Mi
         # k8s_sensor.deployment.pod.limits.cpu sets the CPU units allocation limits for the agent pods.
         cpu: 500m
+      affinity:
+        podAntiAffinity:
+          # Soft anti-affinity policy: try not to schedule multiple kubernetes-sensor pods on the same node.
+          # If the policy is set to "requiredDuringSchedulingIgnoredDuringExecution", if the cluster has
+          # fewer nodes than the amount of desired replicas, `helm install/upgrade --wait` will not return.
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: instana/agent-mode
+                  operator: In
+                  values: [ KUBERNETES ]
+              topologyKey: "kubernetes.io/hostname"
+  podDisruptionBudget:
+    # Specifies whether or not to setup a pod disruption budget for the k8sensor deployment
+    enabled: false
 
 kubernetes:
   # Configures use of a Deployment for the Kubernetes sensor rather than as a potential member of the DaemonSet. Is only accepted if k8s_sensor.deployment.enabled=false


### PR DESCRIPTION
# Add pdb and affinity override for k8sensor

## Why

Allow specifying how the k8sensor is scheduled on kubernetes. Provide a mechanism to limit disruption during cluster maintenance.

## What

- Add an override setting for the k8sensor pod affinity
- Add an optional pdb for the k8sensor

## Checklist

<!-- Please tick of these checklist items if applicable (or remove if not applicable). -->

- [x] Backwards compatible?
- [ ] Documentation added to the README.md?
- [x] Changelog updated?
