### PR TITLE
Fix proxy password variable name for k8sensor deployment

### DIFF
--- a/instana-agent/templates/k8s-sensor-deployment.yaml
+++ b/instana-agent/templates/k8s-sensor-deployment.yaml
@@ -4,7 +4,7 @@
 
 {{- $user_name_password := "" -}}
 {{ if .Values.agent.proxyUser }}
-  {{- $user_name_password = print .Values.agent.proxyUser ":" .Values.agent.proxyPass "@" -}}
+  {{- $user_name_password = print .Values.agent.proxyUser ":" .Values.agent.proxyPassword "@" -}}
 {{ end}}
 
 apiVersion: apps/v1


### PR DESCRIPTION
# Fix proxy password variable name for k8sensor deployment

## Why

The k8sensor deployment receives `<nil>` as proxy password because the variable name is wrong

## What

The variable name for the proxy password is wrong in k8sensor deployment

## Checklist

- [x] Backwards compatible?
- [  ] Documentation added to the README.md? --> not applicable
- [  ] Changelog updated?
