### PR TITLE
feat(chart): allow configuration of k8s_sensor pod disruption budget

### DIFF
--- a/instana-agent/README.md
+++ b/instana-agent/README.md
@@ -139,7 +139,12 @@ The following table lists the configurable parameters of the Instana chart and t
 | `serviceAccount.name`                               | Name of the ServiceAccount to use                                                                                                                                                                                                                                                                                      | `instana-agent`                                                                                                                         |
 | `zone.name`                                         | Zone that detected technologies will be assigned to                                                                                                                                                                                                                                                                    | `nil` You must provide either `zone.name` or `cluster.name`, see [above](#installation) for details                                     |
 | `zones`                                             | Multi-zone daemonset configuration.                                                                                                                                                                                                                                                                                    | `nil` see [below](#multiple-zones) for details                                                                                          |
-| `k8s_sensor.podDisruptionBudget.enabled`            | Whether to create DisruptionBudget for k8sensor to limit the number of concurrent disruptions                                                                                                                                                                                                                          | `false`                                                                                                                                 |
+| `k8s_sensor.podDisruptionBudget.enabled`            | Whether to create DisruptionBudget for k8sensor to limit the number of concurrent disruptions                                                                                                                                                                                                                          | 
+`false`                                                                                                                                 |
+| `k8s_sensor.podDisruptionBudget.minAvailable`            | Number or percentage of pods that must still be available after the eviction.                                                                                                                                                                                                                          |
+`1`                                                                                                                                 |
+| `k8s_sensor.podDisruptionBudget.maxUnavailable`            | Number or percentage of pods that can be unavailable after the eviction.                                                                                                                                                                                                                          |
+`null`                                                                                                                                 |
 | `k8s_sensor.deployment.pod.affinity`                | `k8sensor` deployment affinity format                                                                                                                                                                                                                                                                                  | `podAntiAffinity` defined in `values.yaml`                                                                                              |
 
 ### Agent Modes
@@ -358,6 +363,10 @@ zones:
 ```
 
 ## Changelog
+
+### 1.2.68
+
+* Allow configuration of k8s_sensor pod disruption budget
 
 ### 1.2.67
 

--- a/instana-agent/templates/k8s-sensor-pod-disruption-budget.yaml
+++ b/instana-agent/templates/k8s-sensor-pod-disruption-budget.yaml
@@ -8,6 +8,7 @@ spec:
   selector:
     matchLabels:
       {{- include "k8s-sensor.selectorLabels" . | nindent 6 }}
-  minAvailable: {{ sub (int .Values.k8s_sensor.deployment.replicas) 1 }}
+  minAvailable: {{ .Values.k8s_sensor.podDisruptionBudget.minAvailable }}
+  maxUnavailable: {{ .Values.k8s_sensor.podDisruptionBudget.maxUnavailable }}
 {{- end -}}
 {{- end -}}

--- a/instana-agent/values.yaml
+++ b/instana-agent/values.yaml
@@ -262,6 +262,8 @@ k8s_sensor:
   podDisruptionBudget:
     # Specifies whether or not to setup a pod disruption budget for the k8sensor deployment
     enabled: false
+    minAvailable: 1
+    maxUnavailable: null
 
 kubernetes:
   # Configures use of a Deployment for the Kubernetes sensor rather than as a potential member of the DaemonSet. Is only accepted if k8s_sensor.deployment.enabled=false


### PR DESCRIPTION
# allow configuration of k8s_sensor pod disruption budget

## Why

Depending on the replication settings, a pod disruption budget with `minAvailable` might block a automated node update. It some cases it might be beneficial to allow the re-configuration of the pdb to use `maxUnavailable` instead.

## What

Allow configuration of the k8s_sensor pod disruption budget from the values.yaml

## Checklist

- [x] Backwards compatible?
- [x] Documentation added to the README.md?
- [x] Changelog updated?
