### PR TITLE
[INSTA-17884] feat: Increase default k8sensor pollrate to 10s

### DIFF
--- a/instana-agent/templates/k8s-sensor-deployment.yaml
+++ b/instana-agent/templates/k8s-sensor-deployment.yaml
@@ -57,6 +57,11 @@ spec:
         - name: instana-agent
           image: {{ include "image" .Values.k8s_sensor.image | quote }}
           imagePullPolicy: {{ .Values.k8s_sensor.image.pullPolicy }}
+          command:
+          - /ko-app/k8sensor
+          args:
+          - -pollrate
+          - 10s
           env:
             - name: AGENT_KEY
               valueFrom:


### PR DESCRIPTION
# [INSTA-17884](https://jsw.ibm.com/browse/INSTA-17884) Increase default k8sensor pollrate to 10s

## Why

See internal Jira.

## What

Increases the default pollrate for k8sensor to 10s.

## Checklist

<!-- Please tick of these checklist items if applicable (or remove if not applicable). -->

- [x] Backwards compatible?
- [ ] Documentation added to the README.md?
- [ ] Changelog updated?