### PR TITLE
add missing permission for PDBs

### DIFF
--- a/instana-agent/templates/operator_clusterrole_manager-role.yml
+++ b/instana-agent/templates/operator_clusterrole_manager-role.yml
@@ -42,6 +42,18 @@ rules:
       - list
       - watch
   - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
       - apps.openshift.io
     resources:
       - deploymentconfigs


### PR DESCRIPTION
Hello, when you try to do a fresh install of instana-agent with a pdb enabled for k8s sensor, unfortunately the operator is logging errors and never proceed to creation of deployments / daemonsets etc.

The error in the logs:
{"level":"error","ts":"2024-12-06T12:06:50Z","logger":"instana","msg":"Reconciler error","controller":"instanaagent","controllerGroup":"instana.io","controllerKind":"InstanaAgent","InstanaAgent":{"name":"instana-agent","namespace":"instana-agent"},"namespace":"instana-agent","name":"instana-agent","reconcileID":"15202b79-0ad8-42e1-90fe-74fb130ba531","error":"Multiple Errors:\npoddisruptionbudgets.policy \"instana-agent-k8sensor\" is forbidden: User \"system:serviceaccount:instana-agent:instana-agent-operator\" cannot patch resource \"poddisruptionbudgets\" in API group \"policy\" in the namespace \"instana-agent\"\nMultiple Errors:\nDaemonSet.apps \"instana-agent\" not found\nSecret \"instana-agent-config\" not found\nDaemonSet.apps \"instana-agent\" not found\nDeployment.apps \"instana-agent-k8sensor\" not found\n\n","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.18.5/pkg/internal/controller/controller.go:324\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.18.5/pkg/internal/controller/controller.go:261\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.18.5/pkg/internal/controller/controller.go:222"}

A simple way to test:
- try to create an agent with this value to true: k8s_sensor.podDisruptionBudget.enabled

set it to false in the agent CRD to see the agent being created or put the correct permissions on the cluster role.


