### PR TITLE
Add namespace to uninstall command

### DIFF
--- a/instana-agent/README.md
+++ b/instana-agent/README.md
@@ -95,7 +95,7 @@ If you omit `zone.name`, the host zone will be automatically determined by the a
 To uninstall/delete the `instana-agent` release:
 
 ```bash
-helm uninstall instana-agent -n instana-agent && kubectl patch agent instana-agent -p '{"metadata":{"finalizers":null}}' --type=merge &&
+helm uninstall instana-agent -n instana-agent && kubectl patch agent instana-agent -n instana-agent -p '{"metadata":{"finalizers":null}}' --type=merge &&
 kubectl delete crd/agents.instana.io
 ```
 


### PR DESCRIPTION
## Why

the patch command requires the default namespace `instana-agent`

## What

Add the namespace for the finalizer patching

## Checklist

<!-- Please tick of these checklist items if applicable (or remove if not applicable). -->

- [ ] Backwards compatible?
- [ ] Documentation added to the README.md?
- [ ] Changelog updated?
