### PR TITLE
fix(listenAddress): add quotes to fix formatting issue

### DIFF
--- a/instana-agent/README.md
+++ b/instana-agent/README.md
@@ -423,6 +423,10 @@ $ kubectl exec instana-agent-xxxxx -- ls /opt/instana/agent/etc/application.jks
 
 ## Changelog
 
+### 2.0.11
+
+* Fix rendering of the agent.listenAddress parameter
+
 ### 2.0.10
 
 * Update operator to v2.1.16: Add ClusterRole/ClusterRoleBinding to instana-agent service account to enable prometheus sensor in Kubernetes

--- a/instana-agent/templates/agent.yml
+++ b/instana-agent/templates/agent.yml
@@ -29,7 +29,7 @@ spec:
     keysSecret: {{ .Values.agent.keysSecret }}
 {{- end }}
 {{- if .Values.agent.listenAddress }}
-    listenAddress: {{ .Values.agent.listenAddress }}
+    listenAddress: {{ .Values.agent.listenAddress | quote }}
 {{- end }}
     endpointHost: {{ .Values.agent.endpointHost }}
     {{- if eq (typeOf .Values.agent.endpointPort) "string" }}


### PR DESCRIPTION
# Fix an issue where using the default value for agent.listenAddress would result in an error

## Why

The default value for agent.listenAddress `"*"`, if set, will break the `helm template` part of the deployment.


## What

Adding quotes around the output will escape the "*" character to Helm, without impacting other possible values.

## Checklist

<!-- Please tick of these checklist items if applicable (or remove if not applicable). -->

- [x] Backwards compatible?
- [ ] Documentation added to the README.md?
- [x] Changelog updated?
