### PR TITLE
remove duplicate 'app.kubernetes.io/name' label

### DIFF
--- a/instana-agent/templates/_helpers.tpl
+++ b/instana-agent/templates/_helpers.tpl
@@ -35,7 +35,6 @@ Common labels
 */}}
 {{- define "instana-agent.labels" -}}
 helm.sh/chart: {{ include "instana-agent.chart" . }}
-app.kubernetes.io/name: instana-agent-operator
 {{ include "instana-agent.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}


### PR DESCRIPTION
# Removes the duplicate 'app.kubernetes.io/name' label in the Deployment

## Why
Starting from v2.0.13 the Chart adds "app.kubernetes.io/name" twice in the metadata labels of the Deployment. This label is part of "instana-agent.labels" directly and added a second time by the include of "instana-agent.selectorLabels" in "instana-agent.labels". This is still present in the latest v2.0.17.
https://github.com/instana/helm-charts/blob/123652071ed243432b02f655fe8fbd1d45d271f6/instana-agent/templates/_helpers.tpl#L36

Currently this is rendered:
```
metadata:
  labels:
    helm.sh/chart: instana-agent-2.0.17
    app.kubernetes.io/name: instana-agent-operator
    app.kubernetes.io/name: instana-agent-operator
    app.kubernetes.io/instance: platform
    app.kubernetes.io/managed-by: Helm
```

I run into it using kustomize as Helm post renderer. The rendering will fail with an unmarshal error "mapping key 'app.kubernetes.io/name' already defined".

## What
This change removes the "app.kubernetes.io/name" label from "instana-agent.labels". The label is included from "instana-agent.selectorLabels" and will then exists once under labels in the Deployment.

## Checklist
- [x] Backwards compatible?
- [ ] Documentation added to the README.md?
- [ ] Changelog updated?
