### PR TITLE
Fix broken link in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ You find these Helm charts on [![Artifact HUB](https://img.shields.io/endpoint?u
 ## How to use these Charts
 
 Each chart has its own `README.md` with instructions.
-Additional information may be available in the [Instana documentation](https://www.ibm.com/docs/en/instana-observability/current?topic=agents-installing-host-agent-kubernetes#install-by-using-the-helm-chart).
+Additional information may be available in the [Instana documentation](https://www.ibm.com/docs/en/instana-observability/current?topic=kubernetes-installing-agent#install-by-using-the-helm-chart).
 
 ## Contributing
 


### PR DESCRIPTION
# Fix broken link to installation documentation in `README.md`

## Why

Because the previous link was broken.

## What

Corrected the link.

## Checklist

<!-- Please tick of these checklist items if applicable (or remove if not applicable). -->

- [ ] Backwards compatible?
- [ ] Documentation added to the README.md?
- [ ] Changelog updated?
