### PR TITLE
fix(agent): wrong maxUnavailable-variable used for agent.updateStrategy

### DIFF
--- a/instana-agent/CHANGELOG.md
+++ b/instana-agent/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### 2.0.30
+
+* Fix wrong variable reference in the `agent.yml` template-file. (`.Values.agent.updateStrategy.rollingUpdate.maxUnavailable`)
+
 ### 2.0.29
 
 * Bump operator to v2.1.33: Dependency updates and OLM implementation improvements for AgentRemote permission handling

--- a/instana-agent/templates/agent.yml
+++ b/instana-agent/templates/agent.yml
@@ -123,7 +123,7 @@ spec:
 {{- if .Values.agent.updateStrategy.rollingUpdate }}
 {{- if .Values.agent.updateStrategy.rollingUpdate.maxUnavailable }}
       rollingUpdate:
-        maxUnavailable: {{ .Values.agent.updateStrategy.maxUnavailable }}
+        maxUnavailable: {{ .Values.agent.updateStrategy.rollingUpdate.maxUnavailable }}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
# Fix agent-template to use the correct variable for `.Values.agent.updateStrategy.rollingUpdate.maxUnavailable`

## Why

There's a bug in the agent-template, the variable `.Values.agent.updateStrategy.maxUnavailable` is used instead of `.Values.agent.updateStrategy.rollingUpdate.maxUnavailable`, according to the `values.yaml` file and the README.md documentation.  
This leads to `maxUnavailable` being an empty string in the rendered manifest, when defining `.Values.agent.updateStrategy.rollingUpdate.maxUnavailable` in the values.yaml.

custom-values.yaml:
```
# ...
agent:
  updateStrategy:
    type: RollingUpdate
    rollingUpdate:
      maxUnavailable: 2
# ...

```

rendered manifest without the fix:
```
agent:
...
    updateStrategy:
      type: RollingUpdate
      rollingUpdate:
        maxUnavailable: 
...
```

rendered manifest with the fix
```
agent:
...
    updateStrategy:
      type: RollingUpdate
      rollingUpdate:
        maxUnavailable: 2
...
```



## What

I just changed the variable `.Values.agent.updateStrategy.maxUnavailable` to `.Values.agent.updateStrategy.rollingUpdate.maxUnavailable` in the `agent.yml` file.

## Checklist

- [x] Backwards compatible?
- [x] Changelog updated?
