### PR TITLE
fix(agent): quote image tags to handle them as strings

### DIFF
--- a/instana-agent/templates/agent.yml
+++ b/instana-agent/templates/agent.yml
@@ -101,7 +101,7 @@ spec:
       digest: {{ .Values.agent.image.digest }}
 {{- end }}
 {{- if .Values.agent.image.tag }}
-      tag: {{ .Values.agent.image.tag }}
+      tag: {{ .Values.agent.image.tag | quote }}
 {{- end }}
 {{- if .Values.agent.image.pullPolicy }}
       pullPolicy: {{ .Values.agent.image.pullPolicy }}
@@ -310,7 +310,7 @@ spec:
       digest: {{ .Values.k8s_sensor.image.digest }}
 {{- end }}
 {{- if .Values.k8s_sensor.image.tag }}
-      tag: {{ .Values.k8s_sensor.image.tag }}
+      tag: {{ .Values.k8s_sensor.image.tag | quote }}
 {{- end }}
 {{- if .Values.k8s_sensor.image.pullPolicy }}
       pullPolicy: {{ .Values.k8s_sensor.image.pullPolicy }}


### PR DESCRIPTION
# Treat image.tag values as string

## Why

Bugfix-PR for #32

## What

`.Values.agent.image.tag` and `.Values.k8s_sensor.image.tag` need quotes when rendering, to be treated as string.  
Otherwise, the image tag could be interpreted as a non-string, like a date.

## Checklist

<!-- Please tick of these checklist items if applicable (or remove if not applicable). -->

- [x] Backwards compatible?
- [ ] Documentation added to the README.md?
- [ ] Changelog updated?
