### PR TITLE
Add operator tolerations

### DIFF
--- a/instana-agent/Chart.yaml
+++ b/instana-agent/Chart.yaml
@@ -10,25 +10,25 @@ description: Instana Agent for Kubernetes
 home: https://www.instana.com/
 icon: https://agents.instana.io/helm/stan-logo-2020.png
 maintainers:
-- email: felix.marx@ibm.com
-  name: FelixMarxIBM
-- email: fredrik.gundersen@ibm.com
-  name: FredrikAtIBM
-- email: jefiyamj@ibm.com
-  name: Jefiya-MJ
-- email: konrad.ohms@de.ibm.com
-  name: Konrad-Ohms
-- email: Krishnapriya.RS@ibm.com
-  name: Krishnapriya-RS
-- email: milica.cvrkota@ibm.com
-  name: Milica-Cvrkota-IBM
-- email: Nagaraj.Kandoor@ibm.com
-  name: nagaraj-kandoor
-- email: Rashmi.Swamy@ibm.com
-  name: rashmiswamyibm
-- email: Vineeth.Soman@ibm.com
-  name: vineethsoman03
+  - email: felix.marx@ibm.com
+    name: FelixMarxIBM
+  - email: fredrik.gundersen@ibm.com
+    name: FredrikAtIBM
+  - email: jefiyamj@ibm.com
+    name: Jefiya-MJ
+  - email: konrad.ohms@de.ibm.com
+    name: Konrad-Ohms
+  - email: Krishnapriya.RS@ibm.com
+    name: Krishnapriya-RS
+  - email: milica.cvrkota@ibm.com
+    name: Milica-Cvrkota-IBM
+  - email: Nagaraj.Kandoor@ibm.com
+    name: nagaraj-kandoor
+  - email: Rashmi.Swamy@ibm.com
+    name: rashmiswamyibm
+  - email: Vineeth.Soman@ibm.com
+    name: vineethsoman03
 name: instana-agent
 sources:
-- https://github.com/instana/helm-charts
-version: 2.0.32
+  - https://github.com/instana/helm-charts
+version: 2.0.33

--- a/instana-agent/templates/operator_deployment_instana-agent-controller-manager.yml
+++ b/instana-agent/templates/operator_deployment_instana-agent-controller-manager.yml
@@ -76,6 +76,10 @@ spec:
                       - ppc64le
                       - s390x
                       - arm64
+      {{- if and .Values.controllerManager .Values.controllerManager.pod .Values.controllerManager.pod.tolerations }}
+      tolerations:
+        {{- toYaml .Values.controllerManager.pod.tolerations | nindent 8 }}
+      {{- end }}
       containers:
         - args:
             - --leader-elect

--- a/instana-agent/values.yaml
+++ b/instana-agent/values.yaml
@@ -318,10 +318,15 @@ controllerManager:
     #   - name: my_awesome_secret_instead
     # If you want no imagePullSecrets to be specified in the agent pod, you can just pass an empty array to agent.image.pullSecrets
     pullSecrets: []
-  # resources:
-  #   limits:
-  #     cpu: 200m
-  #     memory: 600Mi
-  #   requests:
-  #     cpu: 200m
-  #     memory: 200Mi
+    # resources:
+    #   limits:
+    #     cpu: 200m
+    #     memory: 600Mi
+    #   requests:
+    #     cpu: 200m
+    #     memory: 200Mi
+    # operator pod-level settings (parallels agent.pod.*)
+    pod:
+      # controllerManager.pod.tolerations are tolerations to influence operator pod assignment.
+      # https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+      tolerations: []


### PR DESCRIPTION
This pull request updates the Instana Agent Helm chart to version 2.0.33 and introduces support for configuring pod-level tolerations for the operator deployment. This allows users to control how the operator pods are scheduled in Kubernetes clusters with taints.

Key changes:

Helm chart version update:
* Bumped the chart version from 2.0.32 to 2.0.33 in `Chart.yaml` to reflect the new changes.

Operator pod scheduling configuration:
* Added a new `pod` section under `controllerManager` in `values.yaml`, including a `tolerations` field for specifying Kubernetes tolerations. This enables users to influence the scheduling of the operator pod.
* Updated the operator deployment template (`operator_deployment_instana-agent-controller-manager.yml`) to conditionally inject the `tolerations` field if it is defined in the values file.